### PR TITLE
修正 run.bat 无法在管理员权限下被启动

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -7,5 +7,6 @@ echo 如无反应 可切换使用管理员权限运行脚本
 set local_python=%~dp0.env\venv\Scripts\python.exe
 set PYTHONPATH=%~dp0/src
 
+cd /D %~dp0
 !local_python! src/gui/app.py
 pause


### PR DESCRIPTION
bat文件以管理员权限被启动时，工作目录处于 C:\Windows\System32，导致无法找到app.py

> Active code page: 65001
如无反应 可切换使用管理员权限运行脚本
C:\Program Files\Python311\python.exe: can't open file 'C:\\Windows\\System32\\src\\gui\\app.py': [Errno 2] No such file or directory

调用local_python前先切换到bat文件所在目录以解决此问题