### PR TITLE
增加设置选项：传送超时等待时间

### DIFF
--- a/config/game_sample.yml
+++ b/config/game_sample.yml
@@ -6,6 +6,7 @@ walk_speed: 20
 run_speed: 25
 turn_dx: 0
 server_region: CN
+transport_timeout: 20.0
 run_mode: 0
 key_interact: 'f'
 key_technique: 'e'

--- a/src/gui/settings/settings_basic_view.py
+++ b/src/gui/settings/settings_basic_view.py
@@ -69,6 +69,8 @@ class SettingsView(components.Card, SrBasicView):
         self.personal_proxy_input = ft.TextField(hint_text='host:port', width=150,
                                                  value='http://127.0.0.1:8234', disabled=True,
                                                  on_change=self._on_personal_proxy_changed)
+        self.transport_timeout_input = ft.TextField(hint_text='20', width=150,
+                                                    value='20', on_change=self._on_transport_timeout_changed)
 
         settings_list = SettingsList(
             controls=[
@@ -78,6 +80,7 @@ class SettingsView(components.Card, SrBasicView):
                 SettingsListItem('游戏区服', self.server_region_dropdown),
                 SettingsListItem('语言', self.lang_dropdown),
                 SettingsListItem('疾跑', self.run_mode_dropdown),
+                SettingsListItem('传送超时时间（秒）', self.transport_timeout_input),
                 SettingsListGroupTitle('按键'),
                 SettingsListItem('交互', self.interact_btn),
                 SettingsListItem('秘技', self.technique_btn),
@@ -111,6 +114,7 @@ class SettingsView(components.Card, SrBasicView):
 
         self.proxy_type_dropdown.value = self.game_config.proxy_type
         self.personal_proxy_input.value = self.game_config.personal_proxy
+        self.transport_timeout_input.value = self.game_config.transport_timeout
         self._update_proxy_part_display()
 
         self.update()
@@ -230,6 +234,11 @@ class SettingsView(components.Card, SrBasicView):
     def _on_personal_proxy_changed(self, e):
         self.game_config.personal_proxy = self.personal_proxy_input.value
 
+    def _on_transport_timeout_changed(self, e):
+        try:
+            self.game_config.transport_timeout = float(self.transport_timeout_input.value)
+        except ValueError:
+            pass
 
 sv: SettingsView = None
 

--- a/src/sr/config/game_config.py
+++ b/src/sr/config/game_config.py
@@ -161,6 +161,22 @@ class GameConfig(ConfigHolder):
         return None
 
     @property
+    def transport_timeout(self) -> float:
+        """
+        传送超时时间
+        :return:
+        """
+        return self.get('transport_timeout', 20)
+    
+    @transport_timeout.setter
+    def transport_timeout(self, new_value: float):
+        """
+        更新传送超时时间
+        :return:
+        """
+        self.update('transport_timeout', new_value)
+        
+    @property
     def key_interact(self) -> str:
         """
         交互按钮

--- a/src/sr/operation/combine/transport.py
+++ b/src/sr/operation/combine/transport.py
@@ -2,6 +2,8 @@ from typing import List
 
 from basic.i18_utils import gt
 from basic.log_utils import log
+from sr.config import game_config
+from sr.config.game_config import GameConfig
 from sr.const.map_const import TransportPoint
 from sr.context import Context
 from sr.operation import Operation, OperationResult
@@ -21,6 +23,7 @@ class Transport(CombineOperation):
         :param ctx: 上下文
         :param tp: 传送点
         """
+        self.gc: GameConfig = game_config.get()
         ops: List[Operation] = []
         ops.append(OpenMap(ctx))
         if ctx.first_transport:
@@ -28,7 +31,7 @@ class Transport(CombineOperation):
         ops.append(ChoosePlanet(ctx, tp.region.planet))
         ops.append(ChooseRegion(ctx, tp.region))
         ops.append(ChooseTransportPoint(ctx, tp))
-        ops.append(WaitInWorld(ctx))
+        ops.append(WaitInWorld(ctx, self.gc.transport_timeout))
 
         super().__init__(ctx, ops,
                          op_name=gt('传送 %s %s %s', 'ui') % (tp.planet.display_name, tp.region.display_name, tp.display_name))


### PR DESCRIPTION
指令点击`传送`后 若加载时间太长会触发`指令[ 等待主界面 ]执行超时`错误 导致锄大地路线执行失败

现增加一个选项 供用户自定义最大传送等待时间